### PR TITLE
Fixes error when leaving game

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,6 +132,7 @@ def main():
             if event.type == pygame.QUIT:
                 run = False
                 pygame.quit()
+                exit()
 
             if event.type == pygame.KEYDOWN:
                 if event.key == pygame.K_LCTRL and len(yellow_bullets) < MAX_BULLETS:


### PR DESCRIPTION
Was receiving 'pygame.error: video system not initialized' after closing pygame window.